### PR TITLE
Feature/sign-up: 회원가입 api 연결 및 이름, 이메일 중복 검사

### DIFF
--- a/src/apis/profile.ts
+++ b/src/apis/profile.ts
@@ -15,3 +15,31 @@ export const fetchPost = async () => {
     console.error(e);
   }
 };
+
+export const isNameDuplicated = async (name: string) => {
+  const { data, error } = await supabase
+    .from('profile')
+    .select('id')
+    .eq('name', name.trim());
+
+  if (error) {
+    console.error('이름 중복 확인 실패:', error.message);
+    return false;
+  }
+
+  return data.length > 0;
+};
+
+export const isEmailDuplicated = async (email: string) => {
+  const { data, error } = await supabase
+    .from('profile')
+    .select('id')
+    .eq('email', email.trim());
+
+  if (error) {
+    console.error('이메일 중복 확인 실패:', error.message);
+    return false;
+  }
+
+  return data.length > 0;
+};

--- a/src/components/common/SignUpModal.tsx
+++ b/src/components/common/SignUpModal.tsx
@@ -222,7 +222,7 @@ export default function SignUpModal() {
                 className="flex items-center gap-[5px] font-bold text-[#333]"
               >
                 비밀번호
-                <Tooltip title="비밀번호는 8자 이상 16자 이하, 영문 대소문자 숫자, 특수문자를 포함하여 입력해주세요.">
+                <Tooltip title="비밀번호는 8자 이상 16자 이하, 영문 대소문자, 숫자, 특수문자를 포함하여 입력해주세요.">
                   <div className="size-[16px] items-center justify-center rounded-full border-1 text-center text-[10px]">
                     ?
                   </div>

--- a/src/components/common/SignUpModal.tsx
+++ b/src/components/common/SignUpModal.tsx
@@ -63,7 +63,7 @@ export default function SignUpModal() {
     register,
     handleSubmit,
     formState: { isSubmitting, isSubmitted, errors },
-  } = useForm();
+  } = useForm({ mode: 'onChange' });
 
   return (
     <>

--- a/src/components/common/SignUpModal.tsx
+++ b/src/components/common/SignUpModal.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import { IoMdCheckmark } from 'react-icons/io';
 import { IoMdClose } from 'react-icons/io';
 import supabase from '../../utils/supabase';
+import { isEmailDuplicated, isNameDuplicated } from '../../apis/profile';
 
 type ConsentKey = 'use' | 'personal' | 'marketing';
 
@@ -27,34 +28,6 @@ export default function SignUpModal() {
       return { ...prev, [type]: !prev[type] };
     });
     setChecked(false);
-  };
-
-  const isNameDuplicated = async (name: string) => {
-    const { data, error } = await supabase
-      .from('profile')
-      .select('id')
-      .eq('name', name);
-
-    if (error) {
-      console.error('중복 확인 실패:', error.message);
-      return false;
-    }
-
-    return data.length > 0;
-  };
-
-  const isEmailDuplicated = async (email: string) => {
-    const { data, error } = await supabase
-      .from('profile')
-      .select('id')
-      .eq('email', email);
-
-    if (error) {
-      console.error('이메일 중복 확인 실패:', error.message);
-      return false;
-    }
-
-    return data.length > 0;
   };
 
   const handleCheckValid = () => {

--- a/src/components/common/SignUpModal.tsx
+++ b/src/components/common/SignUpModal.tsx
@@ -162,7 +162,7 @@ export default function SignUpModal() {
                         resolve(
                           duplicated ? '이미 사용 중인 이름입니다.' : true,
                         );
-                      }, 500);
+                      }, 300);
                     });
                   },
                 })}
@@ -202,7 +202,7 @@ export default function SignUpModal() {
                         resolve(
                           duplicated ? '이미 사용 중인 이메일입니다.' : true,
                         );
-                      }, 500);
+                      }, 300);
                     });
                   },
                 })}

--- a/src/components/common/SignUpModal.tsx
+++ b/src/components/common/SignUpModal.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { IoMdCheckmark } from 'react-icons/io';
 import { IoMdClose } from 'react-icons/io';
+import supabase from '../../utils/supabase';
 
 type ConsentKey = 'use' | 'personal' | 'marketing';
 
@@ -19,12 +20,41 @@ export default function SignUpModal() {
   });
   const background = useRef(null);
   const closeButton = useRef(null);
+  const debounceTimer = useRef<NodeJS.Timeout | null>(null);
 
   const handleConsentClick = (type: ConsentKey) => {
     setConsent((prev) => {
       return { ...prev, [type]: !prev[type] };
     });
     setChecked(false);
+  };
+
+  const isNameDuplicated = async (name: string) => {
+    const { data, error } = await supabase
+      .from('profile')
+      .select('id')
+      .eq('name', name);
+
+    if (error) {
+      console.error('중복 확인 실패:', error.message);
+      return false;
+    }
+
+    return data.length > 0;
+  };
+
+  const isEmailDuplicated = async (email: string) => {
+    const { data, error } = await supabase
+      .from('profile')
+      .select('id')
+      .eq('email', email);
+
+    if (error) {
+      console.error('이메일 중복 확인 실패:', error.message);
+      return false;
+    }
+
+    return data.length > 0;
   };
 
   const handleCheckValid = () => {
@@ -89,7 +119,47 @@ export default function SignUpModal() {
             <form
               noValidate
               onSubmit={handleSubmit(async (data) => {
-                console.log(data);
+                if (!consent.use || !consent.personal) {
+                  setCheckValid(true);
+                  return;
+                }
+
+                const { name, email, password } = data;
+
+                const { data: signUpData, error: signUpError } =
+                  await supabase.auth.signUp({
+                    email,
+                    password,
+                    options: {
+                      data: {
+                        name: name,
+                      },
+                    },
+                  });
+
+                if (signUpError) {
+                  console.error('회원가입 실패:', signUpError.message);
+                  return;
+                }
+
+                const userId = signUpData.user?.id;
+
+                if (!userId) {
+                  console.error('회원가입은 되었지만 사용자 ID가 없습니다.');
+                  return;
+                }
+
+                const { error: profileError } = await supabase
+                  .from('profile')
+                  .upsert([{ id: userId, name: name, email: email }]);
+
+                if (profileError) {
+                  console.error('프로필 저장 실패:', profileError.message);
+                  return;
+                }
+
+                console.log('회원가입 성공');
+                setView(false); // 모달 닫기
               })}
               className="flex w-full flex-col gap-[10px] text-[#333]"
             >
@@ -103,8 +173,24 @@ export default function SignUpModal() {
                 {...register('name', {
                   required: '이름을 입력해 주세요',
                   pattern: {
-                    value: /^[가-힣]{2,5}$/,
-                    message: '2자 이상 5자이하 한글로 작성해 주세요.',
+                    value: /^[A-Za-z가-힣0-9]{2,10}$/,
+                    message:
+                      '2자 이상 10자 이하로 작성해주세요. 특수문자는 불가능합니다.',
+                  },
+                  setValueAs: (value) => value.trim(),
+                  validate: (value) => {
+                    return new Promise((resolve) => {
+                      if (debounceTimer.current) {
+                        clearTimeout(debounceTimer.current);
+                      }
+
+                      debounceTimer.current = setTimeout(async () => {
+                        const duplicated = await isNameDuplicated(value);
+                        resolve(
+                          duplicated ? '이미 사용 중인 이름입니다.' : true,
+                        );
+                      }, 500);
+                    });
                   },
                 })}
                 aria-invalid={
@@ -131,6 +217,21 @@ export default function SignUpModal() {
                     value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
                     message: '이메일 형식에 맞지 않습니다',
                   },
+                  setValueAs: (value) => value.trim(),
+                  validate: (value) => {
+                    return new Promise((resolve) => {
+                      if (debounceTimer.current) {
+                        clearTimeout(debounceTimer.current);
+                      }
+
+                      debounceTimer.current = setTimeout(async () => {
+                        const duplicated = await isEmailDuplicated(value);
+                        resolve(
+                          duplicated ? '이미 사용 중인 이메일입니다.' : true,
+                        );
+                      }, 500);
+                    });
+                  },
                 })}
                 aria-invalid={
                   isSubmitted ? (errors.email ? 'true' : 'false') : undefined
@@ -148,7 +249,7 @@ export default function SignUpModal() {
                 className="flex items-center gap-[5px] font-bold text-[#333]"
               >
                 비밀번호
-                <Tooltip title="비밀번호는 8자 이상 16자 이하, 영문과 숫자, 특수문자를 포함하여 입력해주세요.">
+                <Tooltip title="비밀번호는 8자 이상 16자 이하, 영문 대소문자 숫자, 특수문자를 포함하여 입력해주세요.">
                   <div className="size-[16px] items-center justify-center rounded-full border-1 text-center text-[10px]">
                     ?
                   </div>
@@ -163,10 +264,12 @@ export default function SignUpModal() {
                   minLength: {
                     value: 8,
                     message:
-                      '2자 이상 10자 이하의 한글, 영문, 숫자만 입력해주세요.',
+                      '8자리 이상 16자리 이하의 비밀번호를 입력해주세요.',
                   },
+                  setValueAs: (value) => value.trim(),
                   pattern: {
-                    value: /^[A-Za-z가-힣0-9]{2,10}$/,
+                    value:
+                      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()_+~`\-={}[\]:;"'<>,.?/\\]).{8,16}$/,
                     message: '비밀번호 형식에 맞지 않습니다.',
                   },
                 })}


### PR DESCRIPTION
## ✨ PR 개요

- 회원가입 api 연결
- 이름, 이메일 중복 검사
- 유효성 검사 수정

---

## 🛠️ 작업 상세 내용

이번 PR에서 수행한 작업 유형에 체크해 주세요.

- [x] New Feature (새 기능 추가)
- [ ] Bug Fix (버그 수정)
- [ ] Remove Feature (기능 제거)
- [ ] Change Logic (로직 수정)
- [ ] Style (스타일 수정: 코드 포맷, CSS 등)
- [ ] Test (테스트 코드 추가/수정)
- [ ] Set up (환경 설정, 패키지 설정 등)

---
## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/63f65916-8377-4b8b-9e70-9535d97d0bc2

---

## ✍️ 리뷰 시 참고 사항
유효성 검사 변경할 부분 있으면 말씀해 주세요.
이름: 영어 대소문자, 숫자, 한글로 2 ~ 10자(특수문자, 띄어쓰기 불가)
- 안내 메시지: 2자 이상 10자 이하로 작성해 주세요. 특수문자는 불가능합니다.

비밀번호: 영어 대소문자, 숫자, 특수문자 반드시 포함하여 8~16자
- 안내 메시지: 비밀번호 형식에 맞지 않습니다.

비밀번호 형식은 ? 아이콘에 호버 시 툴팁 형태로 나가도록 해두신 거 같습니다.

한번 제출해야 유효성 검사가 실행됩니다. 
중복 검사는 유효성 검사를 통과해야만 실행이 됩니다.
유효성 검사는 onChange 시마다 검사하고, 중복 검사는 입력 종료 후 0.5초 후에 실행됩니다
apis/profile.ts에 이름 중복, 이메일 중복 함수 만들어 두었습니다.